### PR TITLE
Return tag (and a little extra)

### DIFF
--- a/src/PhpDocReader/CannotResolveException.php
+++ b/src/PhpDocReader/CannotResolveException.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace PhpDocReader;
+
+use ReflectionMethod;
+use ReflectionParameter;
+use ReflectionProperty;
+use Reflector;
+
+class CannotResolveException extends AnnotationException
+{
+    const GENERIC_MESSAGE = 'The @%s annotation on %s::%s contains a non existent class "%s". Did you maybe forget to add a "use" statement for this annotation?';
+    const PARAM_MESSAGE = 'The @param annotation for parameter "%s" of %s::%s contains a non existent class "%s". Did you maybe forget to add a "use" statement for this annotation?';
+
+    public $type;
+
+    public function __construct($type, Reflector $context)
+    {
+        parent::__construct();
+        $this->type = $type;
+
+        if ($context instanceof ReflectionProperty) {
+            $this->message = sprintf(
+                self::GENERIC_MESSAGE,
+                'var',
+                $context->getDeclaringClass()->name,
+                $context->name,
+                $type
+            );
+        } elseif ($context instanceof ReflectionMethod) {
+            $this->message = sprintf(
+                self::GENERIC_MESSAGE,
+                'method',
+                $context->getDeclaringClass()->name,
+                $context->name,
+                $type
+            );
+        } elseif ($context instanceof ReflectionParameter) {
+            $this->message = sprintf(
+                self::PARAM_MESSAGE,
+                $context->name,
+                $context->getDeclaringClass()->name,
+                $context->getDeclaringFunction()->name,
+                $type
+            );
+        }
+    }
+}

--- a/src/PhpDocReader/InvalidClassException.php
+++ b/src/PhpDocReader/InvalidClassException.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace PhpDocReader;
+
+use ReflectionMethod;
+use ReflectionParameter;
+use ReflectionProperty;
+use Reflector;
+
+class InvalidClassException extends AnnotationException
+{
+    const GENERIC_MESSAGE = 'The @%s annotation on %s::%s contains a non existent class "%s"';
+    const PARAM_MESSAGE = 'The @param annotation for parameter "%s" of %s::%s contains a non existent class "%s"';
+
+    public $type;
+
+    public function __construct($type, Reflector $context)
+    {
+        parent::__construct();
+        $this->type = $type;
+
+        if ($context instanceof ReflectionProperty) {
+            $this->message = sprintf(
+                self::GENERIC_MESSAGE,
+                'var',
+                $context->getDeclaringClass()->name,
+                $context->name,
+                $type
+            );
+        } elseif ($context instanceof ReflectionMethod) {
+            $this->message = sprintf(
+                self::GENERIC_MESSAGE,
+                'method',
+                $context->getDeclaringClass()->name,
+                $context->name,
+                $type
+            );
+        } elseif ($context instanceof ReflectionParameter) {
+            $this->message = sprintf(
+                self::PARAM_MESSAGE,
+                $context->name,
+                $context->getDeclaringClass()->name,
+                $context->getDeclaringFunction()->name,
+                $type
+            );
+        }
+    }
+}

--- a/tests/FixturesReturnTag/Class1.php
+++ b/tests/FixturesReturnTag/Class1.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace UnitTest\PhpDocReader\FixturesReturnTag;
+
+use UnitTest\PhpDocReader\FixturesReturnTag\DependencyClass1 as Foo;
+use UnitTest\PhpDocReader\FixturesReturnTag\DependencyClass2 as Bar;
+
+class Class1
+{
+    /**
+     * @return Foo
+     */
+    public function singleReturnType()
+    {
+
+    }
+
+    /**
+     * @return Foo|Bar
+     */
+    public function multipleReturnType()
+    {
+
+    }
+}

--- a/tests/FixturesReturnTag/DependencyClass1.php
+++ b/tests/FixturesReturnTag/DependencyClass1.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace UnitTest\PhpDocReader\FixturesReturnTag;
+
+class DependencyClass1
+{
+
+}

--- a/tests/FixturesReturnTag/DependencyClass2.php
+++ b/tests/FixturesReturnTag/DependencyClass2.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace UnitTest\PhpDocReader\FixturesReturnTag;
+
+class DependencyClass2
+{
+
+}

--- a/tests/ReturnTagTest.php
+++ b/tests/ReturnTagTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace UnitTest\PhpDocReader;
+
+use PhpDocReader\PhpDocReader;
+use PHPUnit_Framework_TestCase;
+use ReflectionClass;
+use UnitTest\PhpDocReader\FixturesReturnTag\Class1;
+
+/**
+ * @see https://github.com/PHP-DI/PhpDocReader/issues/5
+ */
+class ReturnTagTest extends PHPUnit_Framework_TestCase
+{
+    const DP1 = 'UnitTest\PhpDocReader\FixturesReturnTag\DependencyClass1';
+    const DP2 = 'UnitTest\PhpDocReader\FixturesReturnTag\DependencyClass2';
+
+    /**
+     * This test ensures that the first type in the return tag is properly returned
+     * @see https://github.com/PHP-DI/PhpDocReader/issues/5
+     */
+    public function testGetFirstReturnType()
+    {
+        $parser = new PhpDocReader();
+
+        $target = new Class1();
+
+        $class = new ReflectionClass($target);
+
+        $this->assertEquals(self::DP1, $parser->getMethodReturnClass($class->getMethod("singleReturnType")));
+        $this->assertEquals(self::DP1, $parser->getMethodReturnClass($class->getMethod("multipleReturnType")));
+    }
+
+    /**
+     * This test ensures that the all types in the return tag are properly returned
+     * @see https://github.com/PHP-DI/PhpDocReader/issues/5
+     */
+    public function testGetAllReturnTypes()
+    {
+        $parser = new PhpDocReader();
+
+        $target = new Class1();
+
+        $class = new ReflectionClass($target);
+
+        $types = $parser->getMethodReturnClasses($class->getMethod("singleReturnType"));
+        $this->assertCount(1, $types);
+        $this->assertContains(self::DP1, $types);
+
+        $types = $parser->getMethodReturnClasses($class->getMethod("multipleReturnType"));
+        $this->assertCount(2, $types);
+        $this->assertContains(self::DP1, $types);
+        $this->assertContains(self::DP2, $types);
+    }
+}

--- a/tests/ReturnTagTest.php
+++ b/tests/ReturnTagTest.php
@@ -16,10 +16,10 @@ class ReturnTagTest extends PHPUnit_Framework_TestCase
     const DP2 = 'UnitTest\PhpDocReader\FixturesReturnTag\DependencyClass2';
 
     /**
-     * This test ensures that the first type in the return tag is properly returned
+     * This test ensures that the return tag is properly returned
      * @see https://github.com/PHP-DI/PhpDocReader/issues/5
      */
-    public function testGetFirstReturnType()
+    public function testGetReturnType()
     {
         $parser = new PhpDocReader();
 
@@ -28,7 +28,7 @@ class ReturnTagTest extends PHPUnit_Framework_TestCase
         $class = new ReflectionClass($target);
 
         $this->assertEquals(self::DP1, $parser->getMethodReturnClass($class->getMethod("singleReturnType")));
-        $this->assertEquals(self::DP1, $parser->getMethodReturnClass($class->getMethod("multipleReturnType")));
+        $this->assertEquals(null, $parser->getMethodReturnClass($class->getMethod("multipleReturnType")));
     }
 
     /**


### PR DESCRIPTION
- Fixes #5
- Adds support for multi-type declarations with added functions `getPropertyClasses()`, `getParameterClasses()`, and `getMethodReturnClasses()`
- Parsing tags and resolving types is now generic
- Throws individually typed exceptions `CannotResolveException` and `InvalidClassException` (both inherit `AnnotationException`)

Let me know if there's anything you'd like to see different.
