### PR TITLE
Add iterable to the list of ignored types

### DIFF
--- a/src/PhpDocReader/PhpDocReader.php
+++ b/src/PhpDocReader/PhpDocReader.php
@@ -34,6 +34,7 @@ class PhpDocReader
         'callable',
         'resource',
         'mixed',
+        'iterable',
     );
 
     /**

--- a/tests/FixturesPrimitiveTypes/Class1.php
+++ b/tests/FixturesPrimitiveTypes/Class1.php
@@ -65,6 +65,11 @@ class Class1
     public $mixed;
 
     /**
+     * @var iterable
+     */
+    public $iterable;
+
+    /**
      * @param bool     $bool
      * @param boolean  $boolean
      * @param string   $string
@@ -77,6 +82,7 @@ class Class1
      * @param callable $callable
      * @param resource $resource
      * @param mixed    $mixed
+     * @param iterable $iterable
      */
     public function foo(
         $bool,
@@ -90,7 +96,8 @@ class Class1
         $object,
         $callable,
         $resource,
-        $mixed
+        $mixed,
+        $iterable
     ) {
     }
 } 

--- a/tests/PrimitiveTypesTest.php
+++ b/tests/PrimitiveTypesTest.php
@@ -47,6 +47,7 @@ class PrimitiveTypesTest extends \PHPUnit_Framework_TestCase
             'callable' => array('callable'),
             'resource' => array('resource'),
             'mixed'    => array('mixed'),
+            'iterable' => array('iterable'),
         );
     }
 }


### PR DESCRIPTION
Hi Matthieu,

Before my fix, an exception was thrown when a parameter had the `iterable` type.

P.S. Sorry, I forgot to change the branch before I pushed my fix.